### PR TITLE
Math functions fix for the latest HCC

### DIFF
--- a/lib/include/helper_image.h
+++ b/lib/include/helper_image.h
@@ -629,7 +629,7 @@ compareDataAsFloatThreshold(const T *reference, const T *data, const unsigned in
 
     for (unsigned int i = 0; i < len; ++i)
     {
-        float diff = fabs((float)reference[i] - (float)data[i]);
+        float diff = fabsf((float)reference[i] - (float)data[i]);
         bool comp = (diff < max_error);
         result &= comp;
 
@@ -885,7 +885,7 @@ sdkCompareL2fe(const float *reference, const float *data,
 
     float normRef = sqrtf(ref);
 
-    if (fabs(ref) < 1e-7)
+    if (fabsf(ref) < 1e-7)
     {
 #ifdef _DEBUG
         std::cerr << "ERROR, reference l2-norm is 0\n";

--- a/lib/src/blas/cgemm/cgemm_array_kernels.cpp
+++ b/lib/src/blas/cgemm/cgemm_array_kernels.cpp
@@ -81,8 +81,8 @@ hcblasStatus cgemm_NoTransAB_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x;
       CImg = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -103,13 +103,13 @@ hcblasStatus cgemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					     float_2 alpha, float_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -178,8 +178,8 @@ hcblasStatus cgemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -206,7 +206,7 @@ hcblasStatus cgemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -274,8 +274,8 @@ hcblasStatus cgemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -296,13 +296,13 @@ hcblasStatus cgemm_NoTransAB_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
 					    float_2 alpha, float_2 beta) {
 #define TILESIZE 8
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt(( N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), ( M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -372,8 +372,8 @@ hcblasStatus cgemm_NoTransAB_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -395,13 +395,13 @@ hcblasStatus cgemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    float_2 alpha, float_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -471,8 +471,8 @@ hcblasStatus cgemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -497,7 +497,7 @@ hcblasStatus cgemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -562,8 +562,8 @@ hcblasStatus cgemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -583,13 +583,13 @@ hcblasStatus cgemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    float_2 alpha, float_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -660,8 +660,8 @@ hcblasStatus cgemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -755,8 +755,8 @@ hcblasStatus cgemm_NoTransB_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x;
       CImg = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -779,7 +779,7 @@ hcblasStatus cgemm_TransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -841,8 +841,8 @@ hcblasStatus cgemm_TransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -865,7 +865,7 @@ hcblasStatus cgemm_TransAB_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -927,8 +927,8 @@ hcblasStatus cgemm_TransAB_STEP_TS16XSS16(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -948,13 +948,13 @@ hcblasStatus cgemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 			  	           float_2 alpha, float_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1024,8 +1024,8 @@ hcblasStatus cgemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/cgemm/cgemm_array_kernels_batch.cpp
+++ b/lib/src/blas/cgemm/cgemm_array_kernels_batch.cpp
@@ -82,8 +82,8 @@ hcblasStatus cgemm_NoTransAB_batch_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x;
       CImg = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -104,14 +104,14 @@ hcblasStatus cgemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
 					           float_2 alpha, float_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -181,8 +181,8 @@ hcblasStatus cgemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -210,7 +210,7 @@ hcblasStatus cgemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -278,8 +278,8 @@ hcblasStatus cgemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -301,14 +301,14 @@ hcblasStatus cgemm_NoTransAB_batch_MICRO_TS8XMTS2(hc::accelerator_view accl_view
 					          float_2 alpha, float_2 beta, int batchSize) {
 #define TILESIZE 8
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1)/ MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1)/ MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -378,8 +378,8 @@ hcblasStatus cgemm_NoTransAB_batch_MICRO_TS8XMTS2(hc::accelerator_view accl_view
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -401,14 +401,14 @@ hcblasStatus cgemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          float_2 alpha, float_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -478,8 +478,8 @@ hcblasStatus cgemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -505,7 +505,7 @@ hcblasStatus cgemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -570,8 +570,8 @@ hcblasStatus cgemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -591,14 +591,14 @@ hcblasStatus cgemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          float_2 alpha, float_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -669,8 +669,8 @@ hcblasStatus cgemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -765,8 +765,8 @@ hcblasStatus cgemm_NoTransB_batch_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x;
       CImg = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -790,7 +790,7 @@ hcblasStatus cgemm_TransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -852,8 +852,8 @@ hcblasStatus cgemm_TransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -877,7 +877,7 @@ hcblasStatus cgemm_TransAB_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -939,8 +939,8 @@ hcblasStatus cgemm_TransAB_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -960,14 +960,14 @@ hcblasStatus cgemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         float_2 alpha, float_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1037,8 +1037,8 @@ hcblasStatus cgemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/cgemm/cgemm_array_kernels_rMajor.cpp
+++ b/lib/src/blas/cgemm/cgemm_array_kernels_rMajor.cpp
@@ -81,8 +81,8 @@ hcblasStatus cgemm_TransAB_rMajor_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x;
       CImg = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -106,8 +106,8 @@ hcblasStatus cgemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -177,8 +177,8 @@ hcblasStatus cgemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -205,7 +205,7 @@ hcblasStatus cgemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -273,8 +273,8 @@ hcblasStatus cgemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -299,8 +299,8 @@ hcblasStatus cgemm_TransAB_rMajor_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -370,8 +370,8 @@ hcblasStatus cgemm_TransAB_rMajor_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -396,8 +396,8 @@ hcblasStatus cgemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -467,8 +467,8 @@ hcblasStatus cgemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -493,7 +493,7 @@ hcblasStatus cgemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -558,8 +558,8 @@ hcblasStatus cgemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -582,8 +582,8 @@ hcblasStatus cgemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -654,8 +654,8 @@ hcblasStatus cgemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -749,8 +749,8 @@ hcblasStatus cgemm_NoTransA_rMajor_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x;
       CImg = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -773,7 +773,7 @@ hcblasStatus cgemm_NoTransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -835,8 +835,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -859,7 +859,7 @@ hcblasStatus cgemm_NoTransAB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -921,8 +921,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_vie
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -945,8 +945,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1016,8 +1016,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vi
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/cgemm/cgemm_array_kernels_rMajor_batch.cpp
+++ b/lib/src/blas/cgemm/cgemm_array_kernels_rMajor_batch.cpp
@@ -82,8 +82,8 @@ hcblasStatus cgemm_TransAB_rMajor_batch_loopunroll(hc::accelerator_view accl_vie
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x;
       CImg = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -108,8 +108,8 @@ hcblasStatus cgemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -179,8 +179,8 @@ hcblasStatus cgemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -208,7 +208,7 @@ hcblasStatus cgemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -276,8 +276,8 @@ hcblasStatus cgemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -303,8 +303,8 @@ hcblasStatus cgemm_TransAB_rMajor_batch_MICRO_TS8XMTS2(hc::accelerator_view accl
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -374,8 +374,8 @@ hcblasStatus cgemm_TransAB_rMajor_batch_MICRO_TS8XMTS2(hc::accelerator_view accl
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -401,8 +401,8 @@ hcblasStatus cgemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -472,8 +472,8 @@ hcblasStatus cgemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -499,7 +499,7 @@ hcblasStatus cgemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -564,8 +564,8 @@ hcblasStatus cgemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -589,8 +589,8 @@ hcblasStatus cgemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -661,8 +661,8 @@ hcblasStatus cgemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -757,8 +757,8 @@ hcblasStatus cgemm_NoTransA_rMajor_batch_loopunroll(hc::accelerator_view accl_vi
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x;
       CImg = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -782,7 +782,7 @@ hcblasStatus cgemm_NoTransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -844,8 +844,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -869,7 +869,7 @@ hcblasStatus cgemm_NoTransAB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view ac
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -931,8 +931,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view ac
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -956,8 +956,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view a
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1027,8 +1027,8 @@ hcblasStatus cgemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view a
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/cgemm/cgemm_array_wrapper.cpp
+++ b/lib/src/blas/cgemm/cgemm_array_wrapper.cpp
@@ -18,8 +18,8 @@ hcblasStatus cgemm_alpha0_col(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x;
       CImg = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x = 0.0;
@@ -56,8 +56,8 @@ hcblasStatus cgemm_alpha0_colbatch(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x;
       CImg = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x = 0.0;
@@ -93,8 +93,8 @@ hcblasStatus cgemm_alpha0_row(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x;
       CImg = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x = 0.0;
@@ -131,8 +131,8 @@ hcblasStatus cgemm_alpha0_rowbatch(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x;
       CImg = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x = 0.0;

--- a/lib/src/blas/dasum/dasum_array.cpp
+++ b/lib/src/blas/dasum/dasum_array.cpp
@@ -33,7 +33,7 @@ void dasum_HC(hc::accelerator_view accl_view,
     // fold data into local buffer
     while (idx < n) {
       // reduction of smem and X[idx] with results stored in smem
-      smem += hc::fast_math::fabs(xView[xOffset + hc::index<1>(idx)[0]]);
+      smem += hc::fast_math::fabsf(xView[xOffset + hc::index<1>(idx)[0]]);
       // next chunk
       idx += thread_count;
     }
@@ -107,7 +107,7 @@ void dasum_HC(hc::accelerator_view accl_view,
 
   // 2nd pass reduction
   for(int i = 0; i < tile_count; i++) {
-    *Y = (hc::fast_math::isnan(*Y) || hc::fast_math::isinf(*Y)) ? 0 : *Y;
+    *Y = (hc::fast_math::isnan(static_cast<float>(*Y)) || hc::fast_math::isinf(static_cast<float>(*Y))) ? 0 : *Y;
     *Y += host_global_buffer[ i ] ;
   }
 
@@ -146,7 +146,7 @@ void dasum_HC(hc::accelerator_view accl_view,
     // fold data into local buffer
     while (idx < n) {
       // reduction of smem and X[idx] with results stored in smem
-      smem += hc::fast_math::fabs(xView[xOffset + X_batchOffset * elt + hc::index<1>(idx)[0]]);
+      smem += hc::fast_math::fabsf(xView[xOffset + X_batchOffset * elt + hc::index<1>(idx)[0]]);
       // next chunk
       idx += thread_count;
     }
@@ -220,7 +220,7 @@ void dasum_HC(hc::accelerator_view accl_view,
 
   // 2nd pass reduction
   for(int i = 0; i < tile_count * batchSize ; i++) {
-    *Y = (hc::fast_math::isnan(*Y) || hc::fast_math::isinf(*Y)) ? 0 : *Y;
+    *Y = (hc::fast_math::isnan(static_cast<float>(*Y)) || hc::fast_math::isinf(static_cast<float>(*Y))) ? 0 : *Y;
     *Y += host_global_buffer[ i ] ;
   }
   //free up resources

--- a/lib/src/blas/daxpy/daxpy_array.cpp
+++ b/lib/src/blas/daxpy/daxpy_array.cpp
@@ -15,7 +15,7 @@ void axpy_HC(hc::accelerator_view accl_view,
     hc::parallel_for_each(accl_view, compute_domain.tile(BLOCK_SIZE), [ = ] (hc::tiled_index<1> tidx) [[hc]] {
       if(tidx.global[0] < n) {
         long Y_index = yOffset + tidx.global[0];
-        Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+        Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
         Y[Y_index] += X[xOffset + tidx.global[0]] * alpha;
       }
     })_WAIT1;
@@ -39,7 +39,7 @@ void axpy_HC(hc::accelerator_view accl_view,
       if(tidx.tile[0] != nBlocks - 1) {
         for(int iter = 0; iter < step_sz; iter++) {
           long Y_index = yOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256;
-          Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+          Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
           Y[Y_index] += X[xOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256] * alpha;
         }
       } else {
@@ -48,7 +48,7 @@ void axpy_HC(hc::accelerator_view accl_view,
         for(int iter = 0; iter < n_iter; iter++) {
           if (((nBlocks - 1) * 256 * step_sz + iter * 256 + tidx.local[0]) < n) {
             long Y_index = yOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256;
-            Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+            Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
             Y[Y_index] += X[xOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256] * alpha;
           }
         }
@@ -70,7 +70,7 @@ void axpy_HC(hc::accelerator_view accl_view,
 
       if(tidx.global[1] < n) {
         long Y_index = yOffset + Y_batchOffset * elt + tidx.global[1];
-        Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+        Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
         Y[Y_index] += X[xOffset + X_batchOffset * elt + tidx.global[1]] * alpha;
       }
     })_WAIT1;
@@ -96,7 +96,7 @@ void axpy_HC(hc::accelerator_view accl_view,
       if(tidx.tile[1] != nBlocks - 1) {
         for(int iter = 0; iter < step_sz; iter++) {
           long Y_index = yOffset +  Y_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256;
-          Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+          Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
           Y[Y_index] += X[xOffset +  X_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256] * alpha;
         }
       } else {
@@ -105,7 +105,7 @@ void axpy_HC(hc::accelerator_view accl_view,
         for(int iter = 0; iter < n_iter; iter++) {
           if (((nBlocks - 1) * 256 * step_sz + iter * 256 + tidx.local[1]) < n) {
             long Y_index = yOffset +  Y_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256;
-            Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+            Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
             Y[Y_index] += X[xOffset +  X_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256] * alpha;
           }
         }

--- a/lib/src/blas/dcopy/dcopy_array.cpp
+++ b/lib/src/blas/dcopy/dcopy_array.cpp
@@ -14,7 +14,7 @@ void dcopy_HC(hc::accelerator_view accl_view, long n,
   hc::parallel_for_each(accl_view, compute_domain.tile(BLOCK_SIZE), [ = ] (hc::tiled_index<1> tidx) [[hc]] {
     if(tidx.global[0] < n) {
       long Y_index = yOffset + tidx.global[0];
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] = X[xOffset + tidx.global[0]];
     }
   })_WAIT1;
@@ -31,7 +31,7 @@ void dcopy_HC(hc::accelerator_view accl_view, long n,
 
     if(tidx.global[1] < n) {
       long Y_index = yOffset + Y_batchOffset * elt + tidx.global[1];
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] = X[xOffset + X_batchOffset * elt + tidx.global[1]];
     }
   })_WAIT1;

--- a/lib/src/blas/ddot/ddot_array.cpp
+++ b/lib/src/blas/ddot/ddot_array.cpp
@@ -107,7 +107,7 @@ double ddot_HC(hc::accelerator_view accl_view, long n,
 
   // 2nd pass reduction
   for(int i = 0; i < tile_count; i++) {
-    out = (hc::fast_math::isnan(out) || hc::fast_math::isinf(out)) ? 0 : out;
+    out = (hc::fast_math::isnan(static_cast<float>(out)) || hc::fast_math::isinf(static_cast<float>(out))) ? 0 : out;
     out += host_global_buffer[ i ] ;
   }
 
@@ -223,7 +223,7 @@ double ddot_HC(hc::accelerator_view accl_view, long n,
 
 // 2nd pass reduction
   for(int i = 0; i < tile_count * batchSize; i++) {
-    out = (hc::fast_math::isnan(out) || hc::fast_math::isinf(out)) ? 0 : out;
+    out = (hc::fast_math::isnan(static_cast<float>(out)) || hc::fast_math::isinf(static_cast<float>(out))) ? 0 : out;
     out += host_global_buffer[ i ] ;
   }
 

--- a/lib/src/blas/dgemm/dgemm_NT_kernels.cpp
+++ b/lib/src/blas/dgemm/dgemm_NT_kernels.cpp
@@ -21,7 +21,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M064_N064_K064_TS16XMTS4(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -112,7 +112,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M096_N096_K096_TS16XMTS6(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -229,7 +229,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS2(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -341,7 +341,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS4(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -498,7 +498,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS6(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];

--- a/lib/src/blas/dgemm/dgemm_TN_kernels.cpp
+++ b/lib/src/blas/dgemm/dgemm_TN_kernels.cpp
@@ -20,7 +20,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M064_N064_K064_TS16XMTS4(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -110,7 +110,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M096_N096_K096_TS16XMTS6(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -225,7 +225,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS2(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -336,7 +336,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS4(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -491,7 +491,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS6(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];

--- a/lib/src/blas/dgemm/dgemm_array_kernels.cpp
+++ b/lib/src/blas/dgemm/dgemm_array_kernels.cpp
@@ -13,7 +13,7 @@ hcblasStatus gemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1];
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -66,7 +66,7 @@ hcblasStatus gemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -87,7 +87,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -138,7 +138,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -158,7 +158,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -209,7 +209,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -226,12 +226,12 @@ hcblasStatus gemm_NoTransAB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					        double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2 
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -287,7 +287,7 @@ hcblasStatus gemm_NoTransAB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -307,8 +307,8 @@ hcblasStatus gemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -361,7 +361,7 @@ hcblasStatus gemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -384,8 +384,8 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -443,7 +443,7 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -464,8 +464,8 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -523,7 +523,7 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -543,7 +543,7 @@ hcblasStatus gemm_NoTransA_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -592,7 +592,7 @@ hcblasStatus gemm_NoTransA_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -613,7 +613,7 @@ hcblasStatus gemm_NoTransA_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -662,7 +662,7 @@ hcblasStatus gemm_NoTransA_STEP_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -679,12 +679,12 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					       double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -740,7 +740,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -760,8 +760,8 @@ hcblasStatus gemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				           double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -814,7 +814,7 @@ hcblasStatus gemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -837,8 +837,8 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -897,7 +897,7 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -917,7 +917,7 @@ hcblasStatus gemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -966,7 +966,7 @@ hcblasStatus gemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -986,8 +986,8 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -1046,7 +1046,7 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1064,12 +1064,12 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					       double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -1126,7 +1126,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS ) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1146,8 +1146,8 @@ hcblasStatus gemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				           double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1200,7 +1200,7 @@ hcblasStatus gemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1225,7 +1225,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -1273,7 +1273,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1293,7 +1293,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -1341,7 +1341,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1358,8 +1358,8 @@ hcblasStatus gemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				          double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1412,7 +1412,7 @@ hcblasStatus gemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1520,7 +1520,7 @@ hcblasStatus gemm_TransAB_K1(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -1621,7 +1621,7 @@ hcblasStatus gemm_NoTransAB_K2(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc ;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -1660,7 +1660,7 @@ hcblasStatus gemm_TransAB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1730,7 +1730,7 @@ hcblasStatus gemm_TransAB_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -1834,7 +1834,7 @@ hcblasStatus gemm_NoTransA_K4(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x  * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -1935,7 +1935,7 @@ hcblasStatus gemm_NoTransB_K5(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2057,7 +2057,7 @@ hcblasStatus gemm_TransAB_K6(hc::accelerator_view accl_view,
 
       if (c + cOffset + M * thread_x + thread_y < M * N ) {
         long C_index = c + cOffset + ldc * thread_x + thread_y;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2180,7 +2180,7 @@ hcblasStatus gemm_TransAB_K7(hc::accelerator_view accl_view,
 
       if (c + M * thread_x + thread_y < M * N ) {
         long C_index = c + cOffset + ldc * thread_x + thread_y;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2264,7 +2264,7 @@ hcblasStatus gemm_TransAB_K8(hc::accelerator_view accl_view,
     if ( tidx.global[0] < N && tidx.global[1] < M ) {
       idx = tidx.global[1] + tidx.global[0] * ldc;
       long C_index = cOffset + idx;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = localMemA[thread_y] * localMemB[thread_x] + beta * C[C_index];
     }
   })_WAIT1;
@@ -2319,7 +2319,7 @@ hcblasStatus gemm_TransAB_K9(hc::accelerator_view accl_view,
     // multiply matrix A and matrix B and write all results back to global memory
     if ( gx < N && gy < M ) {
       long C_index = cOffset + gy + gx * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = localVarA * B[bOffset + gx] + beta * C[C_index];
     }
   })_WAIT1;
@@ -2387,7 +2387,7 @@ hcblasStatus gemm_TransAB_K10(hc::accelerator_view accl_view,
       }
 
       long C_index = cOffset + global_idx_i + idx_n * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = sum + beta * C[C_index];
     }
   })_WAIT1;
@@ -2445,7 +2445,7 @@ hcblasStatus gemm_TransAB_11(hc::accelerator_view accl_view,
       }
 
       long C_index = cOffset + global_idx_i + idx_n * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = sum + beta * C[C_index];
     }
   })_WAIT1;
@@ -2548,7 +2548,7 @@ hcblasStatus gemm_TransAB_12(hc::accelerator_view accl_view,
 
       if (addr < M * N ) {
         long C_index = cOffset + addr;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2567,7 +2567,7 @@ hcblasStatus gemm_NoTransAB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2641,7 +2641,7 @@ hcblasStatus gemm_NoTransAB_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -2663,7 +2663,7 @@ hcblasStatus gemm_NoTransA_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2735,7 +2735,7 @@ hcblasStatus gemm_NoTransA_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -2758,7 +2758,7 @@ hcblasStatus gemm_NoTransB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2830,7 +2830,7 @@ hcblasStatus gemm_NoTransB_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -2875,7 +2875,7 @@ hcblasStatus gemm_NoTransAB_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row * ldc + Col;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -2918,7 +2918,7 @@ hcblasStatus gemm_NoTransA_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row * ldc + Col;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -2962,7 +2962,7 @@ hcblasStatus gemm_NoTransB_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row * ldc + Col;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }

--- a/lib/src/blas/dgemm/dgemm_array_kernels_batch.cpp
+++ b/lib/src/blas/dgemm/dgemm_array_kernels_batch.cpp
@@ -13,7 +13,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double *A_mat = A[elt];
     double *B_mat = B[elt];
@@ -70,7 +70,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -94,7 +94,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -145,7 +145,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -162,12 +162,12 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     double *A_mat = A[elt];
     double *B_mat = B[elt];
@@ -227,7 +227,7 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -254,7 +254,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -305,7 +305,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -322,8 +322,8 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -380,7 +380,7 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -402,8 +402,8 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -465,7 +465,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -485,7 +485,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double *A_mat = A[elt];
     double *B_mat = B[elt];
@@ -538,7 +538,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -558,8 +558,8 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -621,7 +621,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -645,7 +645,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -694,7 +694,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -711,8 +711,8 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -720,7 +720,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -776,7 +776,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -795,8 +795,8 @@ hcblasStatus gemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -853,7 +853,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -879,8 +879,8 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -939,7 +939,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -963,7 +963,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -1012,7 +1012,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + (gidx * TILESIZE + idx) + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1036,8 +1036,8 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -1096,7 +1096,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1113,8 +1113,8 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1122,7 +1122,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -1179,7 +1179,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS ) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1198,8 +1198,8 @@ hcblasStatus gemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         double alpha, double beta, int batchSize) {	
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1256,7 +1256,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1282,7 +1282,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -1330,7 +1330,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1354,7 +1354,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vie
     double *A_mat = A[elt];
     double *B_mat = B[elt];
     double *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -1402,7 +1402,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vie
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1419,8 +1419,8 @@ hcblasStatus gemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				                double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1477,7 +1477,7 @@ hcblasStatus gemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1498,8 +1498,8 @@ hcblasStatus gemm_NoTransAB_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1558,7 +1558,7 @@ hcblasStatus gemm_NoTransAB_batch_largeM(hc::accelerator_view accl_view,
       for (int row = 0; row < MICROTILESIZE_B ; row++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE_A * col) + (yIndex + TILESIZE_B * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1581,8 +1581,8 @@ hcblasStatus gemm_NoTransA_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 2
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1645,7 +1645,7 @@ hcblasStatus gemm_NoTransA_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex / ldc) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE_A * col) + yIndex + (TILESIZE_B * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1668,8 +1668,8 @@ hcblasStatus gemm_NoTransB_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1728,7 +1728,7 @@ hcblasStatus gemm_NoTransB_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE_A * col) + (yIndex + TILESIZE_B * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }

--- a/lib/src/blas/dgemm/dgemm_array_kernels_rMajor.cpp
+++ b/lib/src/blas/dgemm/dgemm_array_kernels_rMajor.cpp
@@ -18,7 +18,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -66,7 +66,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vi
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -91,7 +91,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -139,7 +139,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -161,8 +161,8 @@ hcblasStatus gemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
 					           double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -215,7 +215,7 @@ hcblasStatus gemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -243,7 +243,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -292,7 +292,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -318,8 +318,8 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -378,7 +378,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -404,8 +404,8 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -464,7 +464,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -487,12 +487,12 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -549,7 +549,7 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -574,8 +574,8 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -628,7 +628,7 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -655,8 +655,8 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -714,7 +714,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -737,12 +737,12 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -798,7 +798,7 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -825,7 +825,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -874,7 +874,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -900,7 +900,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -949,7 +949,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -972,8 +972,8 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1026,7 +1026,7 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1054,8 +1054,8 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -1113,7 +1113,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1136,12 +1136,12 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -1197,7 +1197,7 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex  + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1225,7 +1225,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -1276,7 +1276,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1301,7 +1301,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -1352,7 +1352,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1375,8 +1375,8 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         double alpha, double beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1429,7 +1429,7 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1457,7 +1457,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1];
     double rA[1][STEPSIZE / TILESIZE];
     double rB[1][STEPSIZE / TILESIZE];
@@ -1510,7 +1510,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1553,7 +1553,7 @@ hcblasStatus gemm_TransAB_rMajor_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row + Col * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -1596,7 +1596,7 @@ hcblasStatus gemm_NoTransB_rMajor_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row + Col * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -1640,7 +1640,7 @@ hcblasStatus gemm_NoTransA_rMajor_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row + Col * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }

--- a/lib/src/blas/dgemm/dgemm_array_kernels_rMajor_batch.cpp
+++ b/lib/src/blas/dgemm/dgemm_array_kernels_rMajor_batch.cpp
@@ -18,7 +18,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view a
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
@@ -67,7 +67,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view a
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -93,7 +93,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPTILERATIO];
     double rB[1][STEPTILERATIO];
@@ -141,7 +141,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -163,8 +163,8 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
 						         double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -218,7 +218,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -246,7 +246,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
@@ -296,7 +296,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -322,8 +322,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     double rC[1][1] = {{0.0}};
@@ -383,7 +383,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -409,8 +409,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     double rC[1][1] = {{0.0}};
@@ -470,7 +470,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -493,12 +493,12 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
 							    double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE) + 1);
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE) + 1); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE) + 1);
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE) + 1); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
@@ -556,7 +556,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -581,8 +581,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
 						        double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE) + 1);
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE) + 1); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE) + 1);
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE) + 1); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -636,7 +636,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -663,8 +663,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     double rC[1][1] = {{0.0}};
@@ -723,7 +723,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -746,12 +746,12 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
 							    double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
@@ -808,7 +808,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -836,7 +836,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
@@ -886,7 +886,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -912,7 +912,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view accl
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1] = {{(double)0}};
     double rA[1][STEPSIZE / TILESIZE];
@@ -962,7 +962,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view accl
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -985,8 +985,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
 						        double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1040,7 +1040,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1068,8 +1068,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     double rC[1][1] = {{0.0}};
@@ -1128,7 +1128,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1151,12 +1151,12 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view 
 						           double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     double rC[MICROTILESIZE][MICROTILESIZE] = {{(double)0}};
     double rA[1][MICROTILESIZE];
     double rB[1][MICROTILESIZE];
@@ -1213,7 +1213,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view 
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex  + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1240,7 +1240,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view acc
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -1292,7 +1292,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view acc
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1317,7 +1317,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view a
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1] = {{0.0}};
     double rA[1][STEPTILERATIO];
@@ -1369,7 +1369,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view a
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1392,8 +1392,8 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view accl
 						       double alpha, double beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1447,7 +1447,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view accl
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1475,7 +1475,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_vi
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     double rC[1][1];
     double rA[1][STEPSIZE / TILESIZE];
@@ -1529,7 +1529,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_vi
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1548,8 +1548,8 @@ hcblasStatus gemm_TransAB_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1605,7 +1605,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_largeM(hc::accelerator_view accl_view,
       for (int row = 0; row < MICROTILESIZE_B ; row++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + TILESIZE_A * col) * ldc + yIndex + TILESIZE_B * row;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1628,8 +1628,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 2
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1689,7 +1689,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if ((xIndex / ldc) + (TILESIZE_A * col) < M && yIndex + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE_A * col) * ldc) + yIndex + (TILESIZE_B * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1712,8 +1712,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1769,7 +1769,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + TILESIZE_A * col) * ldc + yIndex + TILESIZE_B * row;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }

--- a/lib/src/blas/dgemm/dgemm_array_wrapper.cpp
+++ b/lib/src/blas/dgemm/dgemm_array_wrapper.cpp
@@ -117,7 +117,7 @@ hcblasStatus gemm_alpha0_col(hc::accelerator_view accl_view,
     int Col = tidx.tile[1];
     if (threadIdx == 0 && Col < M && Row < N) {
         long C_index = cOffset + Row * ldc + Col;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
 	if (alpha == 0 ) {
 	  if ( beta == 0 ) {
             C[C_index] = 0.0;
@@ -150,7 +150,7 @@ hcblasStatus gemm_alpha0_col_batch(hc::accelerator_view accl_view,
     int Col = tidx.tile[2];
     if (threadIdx == 0 && Col < M && Row < N) {
     long C_index = cOffset + C_batchOffset * elt + Row * ldc + Col;
-    C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+    C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
     if (alpha == 0 ) {
       if ( beta == 0 ) {
         C[C_index] = 0.0;
@@ -182,7 +182,7 @@ hcblasStatus gemm_alpha0_row(hc::accelerator_view accl_view,
     int Col = tidx.tile[1];
     if (threadIdx == 0 && Col < M && Row < N) {
        long C_index = cOffset + Row + Col * ldc;
-       C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+       C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
        if (alpha == 0 ) {
 	 if ( beta == 0 ) {
            C[C_index] = 0.0;
@@ -215,7 +215,7 @@ hcblasStatus gemm_alpha0_row_batch(hc::accelerator_view accl_view,
     int Col = tidx.tile[2];
     if (threadIdx == 0 && Col < M && Row < N) {
        long C_index = cOffset + C_batchOffset * elt + Row + Col * ldc;
-       C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+       C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
        if (alpha == 0 ) {
          if ( beta == 0 ) {
            C[C_index] = 0.0;

--- a/lib/src/blas/dgemv/dgemv_array.cpp
+++ b/lib/src/blas/dgemv/dgemv_array.cpp
@@ -65,7 +65,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -102,7 +102,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -170,7 +170,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Y_batchOffset * elt + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -208,7 +208,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Y_batchOffset * elt + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -275,7 +275,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -312,7 +312,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -380,7 +380,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Y_batchOffset * elt + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -418,7 +418,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Y_batchOffset * elt + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -459,7 +459,7 @@ static void gemv_NoTransA(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -502,7 +502,7 @@ static void gemv_NoTransA(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -544,7 +544,7 @@ static void gemv_NoTransA_rMajor(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -587,7 +587,7 @@ static void gemv_NoTransA_rMajor(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -609,7 +609,7 @@ static void gemv_alpha0_col(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;
@@ -634,7 +634,7 @@ static void gemv_alpha0_colbatch(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;
@@ -658,7 +658,7 @@ static void gemv_alpha0_row(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;
@@ -683,7 +683,7 @@ static void gemv_alpha0_rowbatch(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;

--- a/lib/src/blas/dger/dger_array.cpp
+++ b/lib/src/blas/dger/dger_array.cpp
@@ -18,7 +18,7 @@ void ger_HC(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + j * lda + i;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + i] * y[yOffset + j] * alpha;
     }
   })_WAIT1;
@@ -42,7 +42,7 @@ void ger_HC(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + A_batchOffset * elt + j * lda + i;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + X_batchOffset * elt + i] * y[yOffset + Y_batchOffset * elt + j] * alpha;
     }
   })_WAIT1;
@@ -62,7 +62,7 @@ void ger_HC_rMajor(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + j + i * lda;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + i] * y[yOffset + j] * alpha;
     }
   })_WAIT1;
@@ -86,7 +86,7 @@ void ger_HC_rMajor(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + A_batchOffset * elt + j + i * lda;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + X_batchOffset * elt + i] * y[yOffset + Y_batchOffset * elt + j] * alpha;
     }
   })_WAIT1;

--- a/lib/src/blas/dscal/dscal_array.cpp
+++ b/lib/src/blas/dscal/dscal_array.cpp
@@ -14,7 +14,7 @@ void dscal_HC(hc::accelerator_view accl_view,
   hc::parallel_for_each(accl_view, compute_domain.tile(BLOCK_SIZE), [ = ] (hc::tiled_index<1> tidx) [[hc]] {
     if(tidx.global[0] < n) {
       long X_index = xOffset + tidx.global[0];
-      X[X_index] = (hc::fast_math::isnan(X[X_index]) || hc::fast_math::isinf(X[X_index])) ? 0 : X[X_index];
+      X[X_index] = (hc::fast_math::isnan(static_cast<float>(X[X_index])) || hc::fast_math::isinf(static_cast<float>(X[X_index]))) ? 0 : X[X_index];
     if (alpha == 0)
       X[X_index] = 0.0;
     else
@@ -34,7 +34,7 @@ void dscal_HC(hc::accelerator_view accl_view,
 
     if(tidx.global[1] < n) {
       long X_index = xOffset + X_batchOffset * elt + tidx.global[1];
-      X[X_index] = (hc::fast_math::isnan(X[X_index]) || hc::fast_math::isinf(X[X_index])) ? 0 : X[X_index];
+      X[X_index] = (hc::fast_math::isnan(static_cast<float>(X[X_index])) || hc::fast_math::isinf(static_cast<float>(X[X_index]))) ? 0 : X[X_index];
     if (alpha == 0)
       X[X_index] = 0.0;
     else

--- a/lib/src/blas/hgemm/hgemm_NT_kernels.cpp
+++ b/lib/src/blas/hgemm/hgemm_NT_kernels.cpp
@@ -698,7 +698,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M064_N064_K064_TS16XMTS4(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -789,7 +789,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M096_N096_K096_TS16XMTS6(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -906,7 +906,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS2(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1018,7 +1018,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS4(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1175,7 +1175,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS6(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];

--- a/lib/src/blas/hgemm/hgemm_TN_kernels.cpp
+++ b/lib/src/blas/hgemm/hgemm_TN_kernels.cpp
@@ -697,7 +697,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M064_N064_K064_TS16XMTS4(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -787,7 +787,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M096_N096_K096_TS16XMTS6(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -902,7 +902,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS2(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1013,7 +1013,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS4(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1168,7 +1168,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS6(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];

--- a/lib/src/blas/hgemm/hgemm_array_kernels.cpp
+++ b/lib/src/blas/hgemm/hgemm_array_kernels.cpp
@@ -13,7 +13,7 @@ hcblasStatus gemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1];
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -87,7 +87,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -158,7 +158,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -226,12 +226,12 @@ hcblasStatus gemm_NoTransAB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					        half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2 
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -307,8 +307,8 @@ hcblasStatus gemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -384,8 +384,8 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -464,8 +464,8 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -543,7 +543,7 @@ hcblasStatus gemm_NoTransA_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -613,7 +613,7 @@ hcblasStatus gemm_NoTransA_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -679,12 +679,12 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					       half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -760,8 +760,8 @@ hcblasStatus gemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				           half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -837,8 +837,8 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -917,7 +917,7 @@ hcblasStatus gemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -986,8 +986,8 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -1064,12 +1064,12 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					       half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1146,8 +1146,8 @@ hcblasStatus gemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				           half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1225,7 +1225,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -1293,7 +1293,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -1358,8 +1358,8 @@ hcblasStatus gemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				          half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1660,7 +1660,7 @@ hcblasStatus gemm_TransAB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2567,7 +2567,7 @@ hcblasStatus gemm_NoTransAB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2663,7 +2663,7 @@ hcblasStatus gemm_NoTransA_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2758,7 +2758,7 @@ hcblasStatus gemm_NoTransB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {

--- a/lib/src/blas/hgemm/hgemm_array_kernels_batch.cpp
+++ b/lib/src/blas/hgemm/hgemm_array_kernels_batch.cpp
@@ -13,7 +13,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half *A_mat = A[elt];
     half *B_mat = B[elt];
@@ -94,7 +94,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -162,12 +162,12 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     half *A_mat = A[elt];
     half *B_mat = B[elt];
@@ -254,7 +254,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -322,8 +322,8 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -402,8 +402,8 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -485,7 +485,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half *A_mat = A[elt];
     half *B_mat = B[elt];
@@ -558,8 +558,8 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -645,7 +645,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -711,8 +711,8 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -720,7 +720,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -795,8 +795,8 @@ hcblasStatus gemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -879,8 +879,8 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -963,7 +963,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -1036,8 +1036,8 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -1113,8 +1113,8 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1122,7 +1122,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1198,8 +1198,8 @@ hcblasStatus gemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         half alpha, half beta, int batchSize) {	
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1282,7 +1282,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -1354,7 +1354,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vie
     half *A_mat = A[elt];
     half *B_mat = B[elt];
     half *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -1419,8 +1419,8 @@ hcblasStatus gemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				                half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1498,8 +1498,8 @@ hcblasStatus gemm_NoTransAB_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1581,8 +1581,8 @@ hcblasStatus gemm_NoTransA_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 2
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1668,8 +1668,8 @@ hcblasStatus gemm_NoTransB_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {

--- a/lib/src/blas/hgemm/hgemm_array_kernels_rMajor.cpp
+++ b/lib/src/blas/hgemm/hgemm_array_kernels_rMajor.cpp
@@ -18,7 +18,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -91,7 +91,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -161,8 +161,8 @@ hcblasStatus gemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
 					           half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -243,7 +243,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -318,8 +318,8 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -404,8 +404,8 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -487,12 +487,12 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -574,8 +574,8 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -655,8 +655,8 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -737,12 +737,12 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -825,7 +825,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -900,7 +900,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];
@@ -972,8 +972,8 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1054,8 +1054,8 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -1136,12 +1136,12 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1225,7 +1225,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -1301,7 +1301,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -1375,8 +1375,8 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         half alpha, half beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1457,7 +1457,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1];
     half rA[1][STEPSIZE / TILESIZE];
     half rB[1][STEPSIZE / TILESIZE];

--- a/lib/src/blas/hgemm/hgemm_array_kernels_rMajor_batch.cpp
+++ b/lib/src/blas/hgemm/hgemm_array_kernels_rMajor_batch.cpp
@@ -18,7 +18,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view a
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
@@ -93,7 +93,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPTILERATIO];
     half rB[1][STEPTILERATIO];
@@ -163,8 +163,8 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
 						         half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -246,7 +246,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
@@ -322,8 +322,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     half rC[1][1] = {{0.0}};
@@ -409,8 +409,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     half rC[1][1] = {{0.0}};
@@ -493,12 +493,12 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
 							    half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE) + 1);
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE) + 1); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE) + 1);
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE) + 1); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
@@ -581,8 +581,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
 						        half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE) + 1);
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE) + 1); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE) + 1);
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE) + 1); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -663,8 +663,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     half rC[1][1] = {{0.0}};
@@ -746,12 +746,12 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
 							    half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
@@ -836,7 +836,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
@@ -912,7 +912,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view accl
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1] = {{(half)0}};
     half rA[1][STEPSIZE / TILESIZE];
@@ -985,8 +985,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
 						        half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1068,8 +1068,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     half rC[1][1] = {{0.0}};
@@ -1151,12 +1151,12 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view 
 						           half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     half rC[MICROTILESIZE][MICROTILESIZE] = {{(half)0}};
     half rA[1][MICROTILESIZE];
     half rB[1][MICROTILESIZE];
@@ -1240,7 +1240,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view acc
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -1317,7 +1317,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view a
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1] = {{0.0}};
     half rA[1][STEPTILERATIO];
@@ -1392,8 +1392,8 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view accl
 						       half alpha, half beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1475,7 +1475,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_vi
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     half rC[1][1];
     half rA[1][STEPSIZE / TILESIZE];
@@ -1548,8 +1548,8 @@ hcblasStatus gemm_TransAB_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1628,8 +1628,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 2
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1712,8 +1712,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {

--- a/lib/src/blas/sasum/sasum_array.cpp
+++ b/lib/src/blas/sasum/sasum_array.cpp
@@ -33,7 +33,7 @@ void sasum_HC(hc::accelerator_view accl_view,
     // fold data into local buffer
     while (idx < n) {
       // reduction of smem and X[idx] with results stored in smem
-      smem += hc::fast_math::fabs(xView[xOffset + hc::index<1>(idx)[0]]);
+      smem += hc::fast_math::fabsf(xView[xOffset + hc::index<1>(idx)[0]]);
       // next chunk
       idx += thread_count;
     }
@@ -107,7 +107,7 @@ void sasum_HC(hc::accelerator_view accl_view,
 
   // 2nd pass reduction
   for(int i = 0; i < tile_count; i++) {
-    *Y = (hc::fast_math::isnan(*Y) || hc::fast_math::isinf(*Y)) ? 0 : *Y;
+    *Y = (hc::fast_math::isnan(static_cast<float>(*Y)) || hc::fast_math::isinf(static_cast<float>(*Y))) ? 0 : *Y;
     *Y += host_global_buffer[ i ] ;
   }
 
@@ -146,7 +146,7 @@ void sasum_HC(hc::accelerator_view accl_view,
     // fold data into local buffer
     while (idx < n) {
       // reduction of smem and X[idx] with results stored in smem
-      smem += hc::fast_math::fabs(xView[xOffset + X_batchOffset * elt + hc::index<1>(idx)[0]]);
+      smem += hc::fast_math::fabsf(xView[xOffset + X_batchOffset * elt + hc::index<1>(idx)[0]]);
       // next chunk
       idx += thread_count;
     }
@@ -220,7 +220,7 @@ void sasum_HC(hc::accelerator_view accl_view,
 
   // 2nd pass reduction
   for(int i = 0; i < tile_count * batchSize; i++) {
-    *Y = (hc::fast_math::isnan(*Y) || hc::fast_math::isinf(*Y)) ? 0 : *Y;
+    *Y = (hc::fast_math::isnan(static_cast<float>(*Y)) || hc::fast_math::isinf(static_cast<float>(*Y))) ? 0 : *Y;
     *Y += host_global_buffer[ i ] ;
   }
 

--- a/lib/src/blas/saxpy/saxpy_array.cpp
+++ b/lib/src/blas/saxpy/saxpy_array.cpp
@@ -15,7 +15,7 @@ void axpy_HC(hc::accelerator_view accl_view,
     hc::parallel_for_each(accl_view, compute_domain.tile(BLOCK_SIZE), [ = ] (hc::tiled_index<1> tidx) [[hc]] {
       if(tidx.global[0] < n) {
         long Y_index = yOffset + tidx.global[0];
-        Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+        Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
         Y[Y_index] += X[xOffset + tidx.global[0]] * alpha;
       }
     })_WAIT1;
@@ -39,7 +39,7 @@ void axpy_HC(hc::accelerator_view accl_view,
       if(tidx.tile[0] != nBlocks - 1) {
         for(int iter = 0; iter < step_sz; iter++) {
           long Y_index = yOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256;
-          Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+          Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
           Y[Y_index] += X[xOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256] * alpha;
         }
       } else {
@@ -48,7 +48,7 @@ void axpy_HC(hc::accelerator_view accl_view,
         for(int iter = 0; iter < n_iter; iter++) {
           if (((nBlocks - 1) * 256 * step_sz + iter * 256 + tidx.local[0]) < n) {
             long Y_index = yOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256;
-            Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+            Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
             Y[Y_index] += X[xOffset + tidx.tile[0] * 256 * step_sz + tidx.local[0] + iter * 256] * alpha;
           }
         }
@@ -70,7 +70,7 @@ void axpy_HC(hc::accelerator_view accl_view,
 
       if(tidx.global[1] < n) {
         long Y_index = yOffset + Y_batchOffset * elt + tidx.global[1];
-        Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+        Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
         Y[Y_index] += X[xOffset + X_batchOffset * elt + tidx.global[1]] * alpha;
       }
     })_WAIT1;
@@ -96,7 +96,7 @@ void axpy_HC(hc::accelerator_view accl_view,
       if(tidx.tile[1] != nBlocks - 1) {
         for(int iter = 0; iter < step_sz; iter++) {
           long Y_index = yOffset +  Y_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256;
-          Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+          Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
           Y[Y_index] += X[xOffset +  X_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256] * alpha;
         }
       } else {
@@ -105,7 +105,7 @@ void axpy_HC(hc::accelerator_view accl_view,
         for(int iter = 0; iter < n_iter; iter++) {
           if (((nBlocks - 1) * 256 * step_sz + iter * 256 + tidx.local[1]) < n) {
             long Y_index = yOffset +  Y_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256;
-            Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+            Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
             Y[Y_index] += X[xOffset +  X_batchOffset * elt + tidx.tile[1] * 256 * step_sz + tidx.local[1] + iter * 256] * alpha;
           }
         }

--- a/lib/src/blas/scopy/scopy_array.cpp
+++ b/lib/src/blas/scopy/scopy_array.cpp
@@ -14,7 +14,7 @@ void scopy_HC(hc::accelerator_view accl_view, long n,
   hc::parallel_for_each(accl_view, compute_domain.tile(BLOCK_SIZE), [ = ] (hc::tiled_index<1> tidx) [[hc]] {
     if(tidx.global[0] < n) {
       long Y_index = yOffset + tidx.global[0];
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] = X[xOffset + tidx.global[0]];
     }
   })_WAIT1;
@@ -31,7 +31,7 @@ void scopy_HC(hc::accelerator_view accl_view, long n,
 
     if(tidx.global[1] < n) {
       long Y_index = yOffset + Y_batchOffset * elt + tidx.global[1];
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] = X[xOffset + X_batchOffset * elt + tidx.global[1]];
     }
   })_WAIT1;

--- a/lib/src/blas/sdot/sdot_array.cpp
+++ b/lib/src/blas/sdot/sdot_array.cpp
@@ -116,7 +116,7 @@ float sdot_HC(hc::accelerator_view accl_view, long n,
   // Assumption : The target architecture has 40 compute units
   if (tile_count < TILE_SIZE * 20) {
     for(int i = 0; i < tile_count; i++) {
-      out = (hc::fast_math::isnan(out) || hc::fast_math::isinf(out)) ? 0 : out;
+      out = (hc::fast_math::isnan(static_cast<float>(out)) || hc::fast_math::isinf(static_cast<float>(out))) ? 0 : out;
       out += host_global_buffer[ i ] ;
     }
   } else
@@ -236,7 +236,7 @@ float sdot_HC(hc::accelerator_view accl_view, long n,
 
   // 2nd pass reduction
   for(int i = 0; i < tile_count * batchSize; i++) {
-    out = (hc::fast_math::isnan(out) || hc::fast_math::isinf(out)) ? 0 : out;
+    out = (hc::fast_math::isnan(static_cast<float>(out)) || hc::fast_math::isinf(static_cast<float>(out))) ? 0 : out;
     out += host_global_buffer[ i ] ;
   }
 

--- a/lib/src/blas/sgemm/sgemm_NT_kernels.cpp
+++ b/lib/src/blas/sgemm/sgemm_NT_kernels.cpp
@@ -698,7 +698,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M064_N064_K064_TS16XMTS4(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -789,7 +789,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M096_N096_K096_TS16XMTS6(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -906,7 +906,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS2(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1018,7 +1018,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS4(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1175,7 +1175,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_M_N_K_TS16XMTS6(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];

--- a/lib/src/blas/sgemm/sgemm_TN_kernels.cpp
+++ b/lib/src/blas/sgemm/sgemm_TN_kernels.cpp
@@ -697,7 +697,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M064_N064_K064_TS16XMTS4(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -787,7 +787,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M096_N096_K096_TS16XMTS6(hc::accelerator_vi
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -902,7 +902,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS2(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1013,7 +1013,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS4(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1168,7 +1168,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_M_N_K_TS16XMTS6(hc::accelerator_view accl_v
   hc::extent<2> grdExt(N_R, M_R);
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];

--- a/lib/src/blas/sgemm/sgemm_array_kernels.cpp
+++ b/lib/src/blas/sgemm/sgemm_array_kernels.cpp
@@ -13,7 +13,7 @@ hcblasStatus gemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1];
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -66,7 +66,7 @@ hcblasStatus gemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -87,7 +87,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -138,7 +138,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -158,7 +158,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -209,7 +209,7 @@ hcblasStatus gemm_NoTransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -226,12 +226,12 @@ hcblasStatus gemm_NoTransAB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					        float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2 
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -287,7 +287,7 @@ hcblasStatus gemm_NoTransAB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -307,8 +307,8 @@ hcblasStatus gemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -361,7 +361,7 @@ hcblasStatus gemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -384,8 +384,8 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -443,7 +443,7 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -464,8 +464,8 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -523,7 +523,7 @@ hcblasStatus gemm_NoTransA_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -543,7 +543,7 @@ hcblasStatus gemm_NoTransA_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -592,7 +592,7 @@ hcblasStatus gemm_NoTransA_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -613,7 +613,7 @@ hcblasStatus gemm_NoTransA_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -662,7 +662,7 @@ hcblasStatus gemm_NoTransA_STEP_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] =  alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -679,12 +679,12 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					       float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -740,7 +740,7 @@ hcblasStatus gemm_NoTransA_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -760,8 +760,8 @@ hcblasStatus gemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				           float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -814,7 +814,7 @@ hcblasStatus gemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -837,8 +837,8 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -897,7 +897,7 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -917,7 +917,7 @@ hcblasStatus gemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -966,7 +966,7 @@ hcblasStatus gemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -986,8 +986,8 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -1046,7 +1046,7 @@ hcblasStatus gemm_NoTransB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1064,12 +1064,12 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
 					       float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1126,7 +1126,7 @@ hcblasStatus gemm_NoTransB_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS ) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1146,8 +1146,8 @@ hcblasStatus gemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				           float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1200,7 +1200,7 @@ hcblasStatus gemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1225,7 +1225,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -1273,7 +1273,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1293,7 +1293,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -1341,7 +1341,7 @@ hcblasStatus gemm_TransAB_STEP_NBK_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1358,8 +1358,8 @@ hcblasStatus gemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				          float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1412,7 +1412,7 @@ hcblasStatus gemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1520,7 +1520,7 @@ hcblasStatus gemm_TransAB_K1(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -1621,7 +1621,7 @@ hcblasStatus gemm_NoTransAB_K2(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc ;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -1660,7 +1660,7 @@ hcblasStatus gemm_TransAB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1730,7 +1730,7 @@ hcblasStatus gemm_TransAB_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -1834,7 +1834,7 @@ hcblasStatus gemm_NoTransA_K4(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x  * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -1935,7 +1935,7 @@ hcblasStatus gemm_NoTransB_K5(hc::accelerator_view accl_view,
 
       if (c + cOffset + thread_y + thread_x * M < M * N ) {
         long C_index = c + cOffset + thread_y + thread_x * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2057,7 +2057,7 @@ hcblasStatus gemm_TransAB_K6(hc::accelerator_view accl_view,
 
       if (c + cOffset + M * thread_x + thread_y < M * N ) {
         long C_index = c + cOffset + ldc * thread_x + thread_y;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2180,7 +2180,7 @@ hcblasStatus gemm_TransAB_K7(hc::accelerator_view accl_view,
 
       if (c + M * thread_x + thread_y < M * N ) {
         long C_index = c + cOffset + ldc * thread_x + thread_y;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2264,7 +2264,7 @@ hcblasStatus gemm_TransAB_K8(hc::accelerator_view accl_view,
     if ( tidx.global[0] < N && tidx.global[1] < M ) {
       idx = tidx.global[1] + tidx.global[0] * ldc;
       long C_index = cOffset + idx;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = localMemA[thread_y] * localMemB[thread_x] + beta * C[C_index];
     }
   })_WAIT1;
@@ -2319,7 +2319,7 @@ hcblasStatus gemm_TransAB_K9(hc::accelerator_view accl_view,
     // multiply matrix A and matrix B and write all results back to global memory
     if ( gx < N && gy < M ) {
       long C_index = cOffset + gy + gx * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = localVarA * B[bOffset + gx] + beta * C[C_index];
     }
   })_WAIT1;
@@ -2387,7 +2387,7 @@ hcblasStatus gemm_TransAB_K10(hc::accelerator_view accl_view,
       }
 
       long C_index = cOffset + global_idx_i + idx_n * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = sum + beta * C[C_index];
     }
   })_WAIT1;
@@ -2445,7 +2445,7 @@ hcblasStatus gemm_TransAB_11(hc::accelerator_view accl_view,
       }
 
       long C_index = cOffset + global_idx_i + idx_n * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = sum + beta * C[C_index];
     }
   })_WAIT1;
@@ -2548,7 +2548,7 @@ hcblasStatus gemm_TransAB_12(hc::accelerator_view accl_view,
 
       if (addr < M * N ) {
         long C_index = cOffset + addr;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = sum + beta * C[C_index];
       }
     }
@@ -2567,7 +2567,7 @@ hcblasStatus gemm_NoTransAB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2641,7 +2641,7 @@ hcblasStatus gemm_NoTransAB_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -2663,7 +2663,7 @@ hcblasStatus gemm_NoTransA_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2735,7 +2735,7 @@ hcblasStatus gemm_NoTransA_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -2758,7 +2758,7 @@ hcblasStatus gemm_NoTransB_K3(hc::accelerator_view accl_view,
 #define TILESIZE 16
 #define HC_WPT 4
 #define HC_RTS 16
-  int N_ = hc::fast_math::fmax(1, (N / HC_WPT));
+  int N_ = hc::fast_math::fmaxf(1, (N / HC_WPT));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -2830,7 +2830,7 @@ hcblasStatus gemm_NoTransB_K3(hc::accelerator_view accl_view,
     for (int w = 0; w < HC_WPT; w++) {
       if (tile_y * TILESIZE + thread_y < M && (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) < N ) {
         long C_index = cOffset + tile_y * TILESIZE + thread_y + (tile_x * TILESIZE * HC_WPT + thread_x + w * HC_RTS) * ldc;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
         C[C_index] = acc[w] + beta * C[C_index];
       }
     }
@@ -2875,7 +2875,7 @@ hcblasStatus gemm_NoTransAB_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row * ldc + Col;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -2918,7 +2918,7 @@ hcblasStatus gemm_NoTransA_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row * ldc + Col;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -2962,7 +2962,7 @@ hcblasStatus gemm_NoTransB_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row * ldc + Col;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }

--- a/lib/src/blas/sgemm/sgemm_array_kernels_batch.cpp
+++ b/lib/src/blas/sgemm/sgemm_array_kernels_batch.cpp
@@ -13,7 +13,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float *A_mat = A[elt];
     float *B_mat = B[elt];
@@ -70,7 +70,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -94,7 +94,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -145,7 +145,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -162,12 +162,12 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     float *A_mat = A[elt];
     float *B_mat = B[elt];
@@ -227,7 +227,7 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -254,7 +254,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -305,7 +305,7 @@ hcblasStatus gemm_NoTransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -322,8 +322,8 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -380,7 +380,7 @@ hcblasStatus gemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -402,8 +402,8 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -465,7 +465,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -485,7 +485,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float *A_mat = A[elt];
     float *B_mat = B[elt];
@@ -538,7 +538,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -558,8 +558,8 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
   hc::extent<3> grdExt(batchSize, (N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -621,7 +621,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -645,7 +645,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -694,7 +694,7 @@ hcblasStatus gemm_NoTransA_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] =  alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -711,8 +711,8 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -720,7 +720,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -776,7 +776,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -795,8 +795,8 @@ hcblasStatus gemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -853,7 +853,7 @@ hcblasStatus gemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -879,8 +879,8 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -939,7 +939,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -963,7 +963,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -1012,7 +1012,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + (gidx * TILESIZE + idx) + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1036,8 +1036,8 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -1096,7 +1096,7 @@ hcblasStatus gemm_NoTransB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
 
     if(crow < M && ccolprod / ldc < N) {
       long C_index = cOffset + C_batchOffset + crow + ccolprod;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1113,8 +1113,8 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1122,7 +1122,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1179,7 +1179,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS ) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1198,8 +1198,8 @@ hcblasStatus gemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         float alpha, float beta, int batchSize) {	
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1256,7 +1256,7 @@ hcblasStatus gemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1282,7 +1282,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -1330,7 +1330,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1354,7 +1354,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vie
     float *A_mat = A[elt];
     float *B_mat = B[elt];
     float *C_mat = C[elt];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -1402,7 +1402,7 @@ hcblasStatus gemm_TransAB_batch_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vie
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc;
-      C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+      C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
       C_mat[C_index] = alpha * rC[0][0] + beta * C_mat[C_index];
     }
   })_WAIT1;
@@ -1419,8 +1419,8 @@ hcblasStatus gemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 				                float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1477,7 +1477,7 @@ hcblasStatus gemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if(xIndex + (TILESIZE * col) < M && (yIndex / ldc) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE * col) + yIndex + (TILESIZE * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1498,8 +1498,8 @@ hcblasStatus gemm_NoTransAB_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1558,7 +1558,7 @@ hcblasStatus gemm_NoTransAB_batch_largeM(hc::accelerator_view accl_view,
       for (int row = 0; row < MICROTILESIZE_B ; row++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE_A * col) + (yIndex + TILESIZE_B * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1581,8 +1581,8 @@ hcblasStatus gemm_NoTransA_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 2
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1645,7 +1645,7 @@ hcblasStatus gemm_NoTransA_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex / ldc) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE_A * col) + yIndex + (TILESIZE_B * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }
@@ -1668,8 +1668,8 @@ hcblasStatus gemm_NoTransB_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1), (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_B, TILESIZE_A);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1728,7 +1728,7 @@ hcblasStatus gemm_NoTransB_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset + (xIndex + TILESIZE_A * col) + (yIndex + TILESIZE_B * row) * ldc;
-          C_mat[C_index] = (hc::fast_math::isnan(C_mat[C_index]) || hc::fast_math::isinf(C_mat[C_index])) ? 0 : C_mat[C_index];
+          C_mat[C_index] = (hc::fast_math::isnan(static_cast<float>(C_mat[C_index])) || hc::fast_math::isinf(static_cast<float>(C_mat[C_index]))) ? 0 : C_mat[C_index];
           C_mat[C_index] = alpha * rC[col][row] + beta * C_mat[C_index];
         }
       }

--- a/lib/src/blas/sgemm/sgemm_array_kernels_rMajor.cpp
+++ b/lib/src/blas/sgemm/sgemm_array_kernels_rMajor.cpp
@@ -18,7 +18,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -66,7 +66,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vi
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -91,7 +91,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -139,7 +139,7 @@ hcblasStatus gemm_NoTransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -161,8 +161,8 @@ hcblasStatus gemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
 					           float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -215,7 +215,7 @@ hcblasStatus gemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -243,7 +243,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -292,7 +292,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -318,8 +318,8 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -378,7 +378,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -404,8 +404,8 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -464,7 +464,7 @@ hcblasStatus gemm_NoTransA_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -487,12 +487,12 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -549,7 +549,7 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -574,8 +574,8 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -628,7 +628,7 @@ hcblasStatus gemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -655,8 +655,8 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -714,7 +714,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_v
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -737,12 +737,12 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
 						      float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -798,7 +798,7 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -825,7 +825,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -874,7 +874,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -900,7 +900,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -949,7 +949,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -972,8 +972,8 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1026,7 +1026,7 @@ hcblasStatus gemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1054,8 +1054,8 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -1113,7 +1113,7 @@ hcblasStatus gemm_NoTransB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_vie
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1136,12 +1136,12 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
 						     float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1197,7 +1197,7 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_NBK_TS16XMTS2(hc::accelerator_view accl_v
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex  + (row << shiftTS) < N) {
           long C_index = cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1225,7 +1225,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -1276,7 +1276,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS8XSS8(hc::accelerator_view accl_view
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1301,7 +1301,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -1352,7 +1352,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_NBK_TS16XSS16(hc::accelerator_view accl_vi
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1375,8 +1375,8 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         float alpha, float beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<2> grdExt((M_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
@@ -1429,7 +1429,7 @@ hcblasStatus gemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1457,7 +1457,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1];
     float rA[1][STEPSIZE / TILESIZE];
     float rB[1][STEPSIZE / TILESIZE];
@@ -1510,7 +1510,7 @@ hcblasStatus gemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1553,7 +1553,7 @@ hcblasStatus gemm_TransAB_rMajor_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row + Col * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -1596,7 +1596,7 @@ hcblasStatus gemm_NoTransB_rMajor_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row + Col * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }
@@ -1640,7 +1640,7 @@ hcblasStatus gemm_NoTransA_rMajor_largeK(hc::accelerator_view accl_view,
 
     if (threadIdx == 0 && Col < M && Row < N) {
       long C_index = cOffset + Row + Col * ldc;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] *= beta;
       C[C_index] += sh[0] * alpha;
     }

--- a/lib/src/blas/sgemm/sgemm_array_kernels_rMajor_batch.cpp
+++ b/lib/src/blas/sgemm/sgemm_array_kernels_rMajor_batch.cpp
@@ -18,7 +18,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view a
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
@@ -67,7 +67,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view a
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -93,7 +93,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPTILERATIO];
     float rB[1][STEPTILERATIO];
@@ -141,7 +141,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -163,8 +163,8 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
 						         float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1));
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -218,7 +218,7 @@ hcblasStatus gemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -246,7 +246,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
@@ -296,7 +296,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -322,8 +322,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     float rC[1][1] = {{0.0}};
@@ -383,7 +383,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -409,8 +409,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = (int)hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = (int)hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     float rC[1][1] = {{0.0}};
@@ -470,7 +470,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -493,12 +493,12 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
 							    float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE) + 1);
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE) + 1); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE) + 1);
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE) + 1); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
@@ -556,7 +556,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -581,8 +581,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
 						        float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE) + 1);
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE) + 1); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE) + 1);
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE) + 1); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -636,7 +636,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -663,8 +663,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     float rC[1][1] = {{0.0}};
@@ -723,7 +723,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view 
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -746,12 +746,12 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
 							    float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     int elt = tidx.tile[0];
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
@@ -808,7 +808,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && (yIndex) + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + ((col << shiftTS) * N)) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -836,7 +836,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
@@ -886,7 +886,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -912,7 +912,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view accl
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1] = {{(float)0}};
     float rA[1][STEPSIZE / TILESIZE];
@@ -962,7 +962,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view accl
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -985,8 +985,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
 						        float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1040,7 +1040,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1068,8 +1068,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int tilemulshift = (int)hc::fast_math::log2(TILESIZE);
-    int shiftfactor = hc::fast_math::log2(STEPSIZE);
+    int tilemulshift = (int)hc::fast_math::log2f(TILESIZE);
+    int shiftfactor = hc::fast_math::log2f(STEPSIZE);
     int block_k = ((K + (STEPSIZE - 1)) & ~(STEPSIZE - 1)) >> shiftfactor;
     int elt = tidx.tile[0];
     float rC[1][1] = {{0.0}};
@@ -1128,7 +1128,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view ac
 
     if(crow / ldc < M && ccolprod < N) {
       long C_index = cOffset + C_batchOffset * elt + crow + ccolprod;
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1151,12 +1151,12 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view 
 						           float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
     float rC[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rA[1][MICROTILESIZE];
     float rB[1][MICROTILESIZE];
@@ -1213,7 +1213,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_NBK_TS16XMTS2(hc::accelerator_view 
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex  + (row << shiftTS) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1240,7 +1240,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view acc
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -1292,7 +1292,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS8XSS8(hc::accelerator_view acc
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1317,7 +1317,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view a
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1] = {{0.0}};
     float rA[1][STEPTILERATIO];
@@ -1369,7 +1369,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_NBK_TS16XSS16(hc::accelerator_view a
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1392,8 +1392,8 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view accl
 						       float alpha, float beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 2
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE + 1)); 
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE + 1)); 
   hc::extent<3> grdExt(batchSize, (M_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1447,7 +1447,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view accl
       for( int col = 0; col < MICROTILESIZE ; col++) {
         if((xIndex / ldc) + (TILESIZE * col) < M && (yIndex) + (TILESIZE * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE * col) * N) + yIndex + (TILESIZE * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1475,7 +1475,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_vi
   hc::extent<3> grdExt(batchSize, (M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     int elt = tidx.tile[0];
     float rC[1][1];
     float rA[1][STEPSIZE / TILESIZE];
@@ -1529,7 +1529,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_vi
 
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       long C_index = cOffset + C_batchOffset * elt + (gidx * TILESIZE + idx) * ldc + (gidy * TILESIZE + idy);
-      C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+      C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
       C[C_index] = alpha * rC[0][0] + beta * C[C_index];
     }
   })_WAIT1;
@@ -1548,8 +1548,8 @@ hcblasStatus gemm_TransAB_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1605,7 +1605,7 @@ hcblasStatus gemm_TransAB_rMajor_batch_largeM(hc::accelerator_view accl_view,
       for (int row = 0; row < MICROTILESIZE_B ; row++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + TILESIZE_A * col) * ldc + yIndex + TILESIZE_B * row;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1628,8 +1628,8 @@ hcblasStatus gemm_NoTransB_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 2
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1689,7 +1689,7 @@ hcblasStatus gemm_NoTransB_rMajor_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if ((xIndex / ldc) + (TILESIZE_A * col) < M && yIndex + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + (TILESIZE_A * col) * ldc) + yIndex + (TILESIZE_B * row);
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }
@@ -1712,8 +1712,8 @@ hcblasStatus gemm_NoTransA_rMajor_batch_largeM(hc::accelerator_view accl_view,
 #define MICROTILESIZE_B 1
 #define TILESIZE_A 32
 #define TILESIZE_B 8
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE_A + 1));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE_B + 1));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE_A + 1));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE_B + 1));
   hc::extent<3> grdExt(batchSize, (M_ + (TILESIZE_A - 1)) & ~(TILESIZE_A - 1), (N_ + (TILESIZE_B - 1)) & ~(TILESIZE_B - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE_A, TILESIZE_B);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
@@ -1769,7 +1769,7 @@ hcblasStatus gemm_NoTransA_rMajor_batch_largeM(hc::accelerator_view accl_view,
       for (int col = 0; col < MICROTILESIZE_A; col++) {
         if (xIndex + (TILESIZE_A * col) < M && (yIndex) + (TILESIZE_B * row) < N) {
           long C_index = cOffset + C_batchOffset * elt + (xIndex + TILESIZE_A * col) * ldc + yIndex + TILESIZE_B * row;
-          C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+          C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
           C[C_index] = alpha * rC[col][row] + beta * C[C_index];
         }
       }

--- a/lib/src/blas/sgemm/sgemm_array_wrapper.cpp
+++ b/lib/src/blas/sgemm/sgemm_array_wrapper.cpp
@@ -117,7 +117,7 @@ hcblasStatus gemm_alpha0_col(hc::accelerator_view accl_view,
     int Col = tidx.tile[1];
     if (threadIdx == 0 && Col < M && Row < N) {
         long C_index = cOffset + Row * ldc + Col;
-        C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+        C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
 	if (alpha == 0 ) {
 	  if ( beta == 0 ) {
             C[C_index] = 0.0;
@@ -150,7 +150,7 @@ hcblasStatus gemm_alpha0_col_batch(hc::accelerator_view accl_view,
     int Col = tidx.tile[2];
     if (threadIdx == 0 && Col < M && Row < N) {
     long C_index = cOffset + C_batchOffset * elt + Row * ldc + Col;
-    C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+    C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
     if (alpha == 0 ) {
       if ( beta == 0 ) {
         C[C_index] = 0.0;
@@ -182,7 +182,7 @@ hcblasStatus gemm_alpha0_row(hc::accelerator_view accl_view,
     int Col = tidx.tile[1];
     if (threadIdx == 0 && Col < M && Row < N) {
        long C_index = cOffset + Row + Col * ldc;
-       C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+       C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
        if (alpha == 0 ) {
 	 if ( beta == 0 ) {
            C[C_index] = 0.0;
@@ -215,7 +215,7 @@ hcblasStatus gemm_alpha0_row_batch(hc::accelerator_view accl_view,
     int Col = tidx.tile[2];
     if (threadIdx == 0 && Col < M && Row < N) {
        long C_index = cOffset + C_batchOffset * elt + Row + Col * ldc;
-       C[C_index] = (hc::fast_math::isnan(C[C_index]) || hc::fast_math::isinf(C[C_index])) ? 0 : C[C_index];
+       C[C_index] = (hc::fast_math::isnan(static_cast<float>(C[C_index])) || hc::fast_math::isinf(static_cast<float>(C[C_index]))) ? 0 : C[C_index];
        if (alpha == 0 ) {
          if ( beta == 0 ) {
            C[C_index] = 0.0;

--- a/lib/src/blas/sgemv/sgemv_array.cpp
+++ b/lib/src/blas/sgemv/sgemv_array.cpp
@@ -65,7 +65,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -103,7 +103,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -171,7 +171,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Y_batchOffset * elt + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -210,7 +210,7 @@ static void gemv_TransA(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Y_batchOffset * elt + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -277,7 +277,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -315,7 +315,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -383,7 +383,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
           tidx.barrier.wait();
           long Y_index = yOffset + Y_batchOffset * elt + Col;
-          Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+          Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
           Y_vec[Y_index] *= beta;
           Y_vec[Y_index] += alpha * sh[0];
         }
@@ -422,7 +422,7 @@ static void gemv_TransA_rMajor(hc::accelerator_view accl_view,
 
       if(threadIdx == 0 && Col < lenY) {
         long Y_index = yOffset + Y_batchOffset * elt + Col;
-        Y_vec[Y_index] = (hc::fast_math::isnan(Y_vec[Y_index]) || hc::fast_math::isinf(Y_vec[Y_index])) ? 0 : Y_vec[Y_index];
+        Y_vec[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y_vec[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y_vec[Y_index]))) ? 0 : Y_vec[Y_index];
         Y_vec[Y_index] *= beta;
         Y_vec[Y_index] += alpha * sh[0];
       }
@@ -463,7 +463,7 @@ static void gemv_NoTransA(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -506,7 +506,7 @@ static void gemv_NoTransA(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -548,7 +548,7 @@ static void gemv_NoTransA_rMajor(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -591,7 +591,7 @@ static void gemv_NoTransA_rMajor(hc::accelerator_view accl_view,
 
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       Y[Y_index] *= beta;
       Y[Y_index] += alpha * Pvalue;
     }
@@ -613,7 +613,7 @@ static void gemv_alpha0_col(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;
@@ -638,7 +638,7 @@ static void gemv_alpha0_colbatch(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;
@@ -662,7 +662,7 @@ static void gemv_alpha0_row(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;
@@ -687,7 +687,7 @@ static void gemv_alpha0_rowbatch(hc::accelerator_view accl_view,
     int Col = bx * BLOCK_SIZE + tx;
     if (Col < lenY) {
       long Y_index = yOffset + Y_batchOffset * elt + Col;
-      Y[Y_index] = (hc::fast_math::isnan(Y[Y_index]) || hc::fast_math::isinf(Y[Y_index])) ? 0 : Y[Y_index];
+      Y[Y_index] = (hc::fast_math::isnan(static_cast<float>(Y[Y_index])) || hc::fast_math::isinf(static_cast<float>(Y[Y_index]))) ? 0 : Y[Y_index];
       if (alpha == 0) {
         if (beta == 0)
           Y[Y_index] = 0.0;

--- a/lib/src/blas/sger/sger_array.cpp
+++ b/lib/src/blas/sger/sger_array.cpp
@@ -18,7 +18,7 @@ void ger_HC(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + j * lda + i;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + i] * y[yOffset + j] * alpha;
     }
   })_WAIT2;
@@ -42,7 +42,7 @@ void ger_HC(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + A_batchOffset * elt + j * lda + i;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + X_batchOffset * elt + i] * y[yOffset + Y_batchOffset * elt + j] * alpha;
     }
   })_WAIT2;
@@ -62,7 +62,7 @@ void ger_HC_rMajor(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + j + i * lda;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + i] * y[yOffset + j] * alpha;
     }
   })_WAIT2;
@@ -86,7 +86,7 @@ void ger_HC_rMajor(hc::accelerator_view accl_view,
 
     if(i < m && j < n) {
       long a_index = aOffset + A_batchOffset * elt + j + i * lda;
-      a[a_index] = (hc::fast_math::isnan(a[a_index]) || hc::fast_math::isinf(a[a_index])) ? 0 : a[a_index];
+      a[a_index] = (hc::fast_math::isnan(static_cast<float>(a[a_index])) || hc::fast_math::isinf(static_cast<float>(a[a_index]))) ? 0 : a[a_index];
       a[a_index] += x[xOffset + X_batchOffset * elt + i] * y[yOffset + Y_batchOffset * elt + j] * alpha;
     }
   })_WAIT2;

--- a/lib/src/blas/sscal/sscal_array.cpp
+++ b/lib/src/blas/sscal/sscal_array.cpp
@@ -14,7 +14,7 @@ void sscal_HC(hc::accelerator_view accl_view,
   hc::parallel_for_each(accl_view, compute_domain.tile(BLOCK_SIZE), [ = ] (hc::tiled_index<1> tidx) [[hc]] {
     if(tidx.global[0] < n) {
       long X_index = xOffset + tidx.global[0];
-      X[X_index] = (hc::fast_math::isnan(X[X_index]) || hc::fast_math::isinf(X[X_index])) ? 0 : X[X_index];
+      X[X_index] = (hc::fast_math::isnan(static_cast<float>(X[X_index])) || hc::fast_math::isinf(static_cast<float>(X[X_index]))) ? 0 : X[X_index];
     if (alpha == 0)
       X[X_index] = 0.0;
     else
@@ -34,7 +34,7 @@ void sscal_HC(hc::accelerator_view accl_view,
 
     if(tidx.global[1] < n) {
       long X_index = xOffset + X_batchOffset * elt + tidx.global[1];
-      X[X_index] = (hc::fast_math::isnan(X[X_index]) || hc::fast_math::isinf(X[X_index])) ? 0 : X[X_index];
+      X[X_index] = (hc::fast_math::isnan(static_cast<float>(X[X_index])) || hc::fast_math::isinf(static_cast<float>(X[X_index]))) ? 0 : X[X_index];
     if (alpha == 0)
       X[X_index] = 0.0;
     else

--- a/lib/src/blas/zgemm/zgemm_array_kernels.cpp
+++ b/lib/src/blas/zgemm/zgemm_array_kernels.cpp
@@ -81,8 +81,8 @@ hcblasStatus zgemm_NoTransAB_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x;
       CImg = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -103,13 +103,13 @@ hcblasStatus zgemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					     double_2 alpha, double_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -178,8 +178,8 @@ hcblasStatus zgemm_NoTransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -206,7 +206,7 @@ hcblasStatus zgemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -274,8 +274,8 @@ hcblasStatus zgemm_NoTransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -296,13 +296,13 @@ hcblasStatus zgemm_NoTransAB_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
 					    double_2 alpha, double_2 beta) {
 #define TILESIZE 8
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt(( N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), ( M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -372,8 +372,8 @@ hcblasStatus zgemm_NoTransAB_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -395,13 +395,13 @@ hcblasStatus zgemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    double_2 alpha, double_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_  + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -471,8 +471,8 @@ hcblasStatus zgemm_NoTransA_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -497,7 +497,7 @@ hcblasStatus zgemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -562,8 +562,8 @@ hcblasStatus zgemm_NoTransB_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -583,13 +583,13 @@ hcblasStatus zgemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					    double_2 alpha, double_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -660,8 +660,8 @@ hcblasStatus zgemm_NoTransB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -755,8 +755,8 @@ hcblasStatus zgemm_NoTransB_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x;
       CImg = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -779,7 +779,7 @@ hcblasStatus zgemm_TransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -841,8 +841,8 @@ hcblasStatus zgemm_TransAB_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -865,7 +865,7 @@ hcblasStatus zgemm_TransAB_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((N + (TILESIZE - 1)) & ~(TILESIZE - 1), (M + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -927,8 +927,8 @@ hcblasStatus zgemm_TransAB_STEP_TS16XSS16(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -948,13 +948,13 @@ hcblasStatus zgemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 			  	           double_2 alpha, double_2 beta) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, (M / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, (N / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, (M / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, (N / MICROTILESIZE));
   hc::extent<2> grdExt((N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1024,8 +1024,8 @@ hcblasStatus zgemm_TransAB_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/zgemm/zgemm_array_kernels_batch.cpp
+++ b/lib/src/blas/zgemm/zgemm_array_kernels_batch.cpp
@@ -82,8 +82,8 @@ hcblasStatus zgemm_NoTransAB_batch_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x;
       CImg = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -104,14 +104,14 @@ hcblasStatus zgemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
 					           double_2 alpha, double_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -181,8 +181,8 @@ hcblasStatus zgemm_NoTransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -210,7 +210,7 @@ hcblasStatus zgemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -278,8 +278,8 @@ hcblasStatus zgemm_NoTransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -301,14 +301,14 @@ hcblasStatus zgemm_NoTransAB_batch_MICRO_TS8XMTS2(hc::accelerator_view accl_view
 					          double_2 alpha, double_2 beta, int batchSize) {
 #define TILESIZE 8
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1)/ MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1)/ MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -378,8 +378,8 @@ hcblasStatus zgemm_NoTransAB_batch_MICRO_TS8XMTS2(hc::accelerator_view accl_view
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -401,14 +401,14 @@ hcblasStatus zgemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          double_2 alpha, double_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -478,8 +478,8 @@ hcblasStatus zgemm_NoTransA_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -505,7 +505,7 @@ hcblasStatus zgemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -570,8 +570,8 @@ hcblasStatus zgemm_NoTransB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -591,14 +591,14 @@ hcblasStatus zgemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
 					          double_2 alpha, double_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -669,8 +669,8 @@ hcblasStatus zgemm_NoTransB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -765,8 +765,8 @@ hcblasStatus zgemm_NoTransB_batch_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x;
       CImg = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -790,7 +790,7 @@ hcblasStatus zgemm_TransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -852,8 +852,8 @@ hcblasStatus zgemm_TransAB_batch_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -877,7 +877,7 @@ hcblasStatus zgemm_TransAB_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -939,8 +939,8 @@ hcblasStatus zgemm_TransAB_batch_STEP_TS16XSS16(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].x;
       CImg = C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy) * ldc].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + gidx * TILESIZE + idx + (gidy * TILESIZE + idy)*ldc].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -960,14 +960,14 @@ hcblasStatus zgemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
 					         double_2 alpha, double_2 beta, int batchSize) {
 #define TILESIZE 16
 #define MICROTILESIZE 1
-  int M_ = hc::fast_math::fmax(1, ((M + 1) / MICROTILESIZE));
-  int N_ = hc::fast_math::fmax(1, ((N + 1) / MICROTILESIZE));
+  int M_ = hc::fast_math::fmaxf(1, ((M + 1) / MICROTILESIZE));
+  int N_ = hc::fast_math::fmaxf(1, ((N + 1) / MICROTILESIZE));
   hc::extent<3> grdExt(batchSize, (N_ + (TILESIZE - 1)) & ~(TILESIZE - 1), (M_ + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1037,8 +1037,8 @@ hcblasStatus zgemm_TransAB_batch_MICRO_TS16XMTS2(hc::accelerator_view accl_view,
         if(xIndex + (col << shiftTS) < M && (yIndex / ldc) + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row * TILESIZE) * ldc].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS)) + yIndex + (row << shiftTS) * ldc].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/zgemm/zgemm_array_kernels_rMajor.cpp
+++ b/lib/src/blas/zgemm/zgemm_array_kernels_rMajor.cpp
@@ -81,8 +81,8 @@ hcblasStatus zgemm_TransAB_rMajor_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x;
       CImg = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -106,8 +106,8 @@ hcblasStatus zgemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -177,8 +177,8 @@ hcblasStatus zgemm_TransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_view
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -205,7 +205,7 @@ hcblasStatus zgemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -273,8 +273,8 @@ hcblasStatus zgemm_TransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -299,8 +299,8 @@ hcblasStatus zgemm_TransAB_rMajor_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -370,8 +370,8 @@ hcblasStatus zgemm_TransAB_rMajor_MICRO_TS8XMTS2(hc::accelerator_view accl_view,
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -396,8 +396,8 @@ hcblasStatus zgemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -467,8 +467,8 @@ hcblasStatus zgemm_NoTransB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -493,7 +493,7 @@ hcblasStatus zgemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -558,8 +558,8 @@ hcblasStatus zgemm_NoTransA_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -582,8 +582,8 @@ hcblasStatus zgemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -654,8 +654,8 @@ hcblasStatus zgemm_NoTransA_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vie
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -749,8 +749,8 @@ hcblasStatus zgemm_NoTransA_rMajor_loopunroll(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x;
       CImg = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -773,7 +773,7 @@ hcblasStatus zgemm_NoTransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -835,8 +835,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_STEP_TS8XSS8(hc::accelerator_view accl_view,
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -859,7 +859,7 @@ hcblasStatus zgemm_NoTransAB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_vie
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -921,8 +921,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_STEP_TS16XSS16(hc::accelerator_view accl_vie
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -945,8 +945,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vi
   hc::extent<2> grdExt((M + (TILESIZE - 1)) & ~(TILESIZE - 1), (N + (TILESIZE - 1)) & ~(TILESIZE - 1));
   hc::tiled_extent<2> t_ext = grdExt.tile(TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<2> tidx) [[hc]] {
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1016,8 +1016,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_MICRO_TS16XMTS2(hc::accelerator_view accl_vi
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/zgemm/zgemm_array_kernels_rMajor_batch.cpp
+++ b/lib/src/blas/zgemm/zgemm_array_kernels_rMajor_batch.cpp
@@ -82,8 +82,8 @@ hcblasStatus zgemm_TransAB_rMajor_batch_loopunroll(hc::accelerator_view accl_vie
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x;
       CImg = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -108,8 +108,8 @@ hcblasStatus zgemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -179,8 +179,8 @@ hcblasStatus zgemm_TransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view acc
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -208,7 +208,7 @@ hcblasStatus zgemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(STEPSIZE);
+    int shiftFactor = hc::fast_math::log2f(STEPSIZE);
     float rCreal[1][1];
     float rAreal[1][STEPSIZE / TILESIZE];
     float rBreal[1][STEPSIZE / TILESIZE];
@@ -276,8 +276,8 @@ hcblasStatus zgemm_TransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_v
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -303,8 +303,8 @@ hcblasStatus zgemm_TransAB_rMajor_batch_MICRO_TS8XMTS2(hc::accelerator_view accl
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -374,8 +374,8 @@ hcblasStatus zgemm_TransAB_rMajor_batch_MICRO_TS8XMTS2(hc::accelerator_view accl
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -401,8 +401,8 @@ hcblasStatus zgemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -472,8 +472,8 @@ hcblasStatus zgemm_NoTransB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -499,7 +499,7 @@ hcblasStatus zgemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -564,8 +564,8 @@ hcblasStatus zgemm_NoTransA_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl_
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -589,8 +589,8 @@ hcblasStatus zgemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -661,8 +661,8 @@ hcblasStatus zgemm_NoTransA_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view ac
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));
@@ -757,8 +757,8 @@ hcblasStatus zgemm_NoTransA_rMajor_batch_loopunroll(hc::accelerator_view accl_vi
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x;
       CImg = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x = tempReal + ((CValue * alpha.x) - (CValue1 * alpha.y));
@@ -782,7 +782,7 @@ hcblasStatus zgemm_NoTransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -844,8 +844,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_batch_STEP_TS8XSS8(hc::accelerator_view accl
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -869,7 +869,7 @@ hcblasStatus zgemm_NoTransAB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view ac
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftFactor = hc::fast_math::log2(TILESIZE);
+    int shiftFactor = hc::fast_math::log2f(TILESIZE);
     float rCreal[1][1];
     float rAreal[1][1];
     float rBreal[1][1];
@@ -931,8 +931,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_batch_STEP_TS16XSS16(hc::accelerator_view ac
     if(gidx * TILESIZE + idx < M && gidy * TILESIZE + idy < N) {
       CReal = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].x;
       CImg = C[elt][cOffset + (gidx * TILESIZE + idx) * ldc + gidy * TILESIZE + idy].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       tempReal = ((CReal * beta.x) - (CImg * beta.y));
       tempImg  = ((CReal * beta.y) + (CImg * beta.x));
       C[elt][cOffset + (gidx * TILESIZE + idx)*ldc + gidy * TILESIZE + idy].x = tempReal + ((rCreal[0][0] * alpha.x) - (rCimg[0][0] * alpha.y));
@@ -956,8 +956,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view a
   hc::tiled_extent<3> t_ext = grdExt.tile(1, TILESIZE, TILESIZE);
   hc::parallel_for_each(accl_view, t_ext, [ = ] (hc::tiled_index<3> &tidx) [[hc]] {
     int elt = tidx.tile[0];
-    int shiftTS = hc::fast_math::log2(TILESIZE);
-    int shiftMTP = hc::fast_math::log2(MICROTILEPROD);
+    int shiftTS = hc::fast_math::log2f(TILESIZE);
+    int shiftMTP = hc::fast_math::log2f(MICROTILEPROD);
     float rCreal[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rCimg[MICROTILESIZE][MICROTILESIZE] = {{(float)0}};
     float rAreal[1][MICROTILESIZE] = {{(float)0}};
@@ -1027,8 +1027,8 @@ hcblasStatus zgemm_NoTransAB_rMajor_batch_MICRO_TS16XMTS2(hc::accelerator_view a
         if((xIndex / ldc) + (col << shiftTS) < M && yIndex + (row << shiftTS) < N) {
           CReal = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x;
           CImg = C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row * TILESIZE)].y;
-          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+          CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+          CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
           tempReal = ((CReal * beta.x) - (CImg * beta.y));
           tempImg  = ((CReal * beta.y) + (CImg * beta.x));
           C[elt][cOffset + (xIndex + (col << shiftTS) * ldc) + yIndex + (row << shiftTS)].x = tempReal + ((rCreal[col][row] * alpha.x) - (rCimg[col][row] * alpha.y));

--- a/lib/src/blas/zgemm/zgemm_array_wrapper.cpp
+++ b/lib/src/blas/zgemm/zgemm_array_wrapper.cpp
@@ -18,8 +18,8 @@ hcblasStatus zgemm_alpha0_col(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x;
       CImg = C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[cOffset + (tidx.global[0] * ldc) + tidx.global[1]].x = 0.0;
@@ -56,8 +56,8 @@ hcblasStatus zgemm_alpha0_colbatch(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x;
       CImg = C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[elt][cOffset + (tidx.global[1] * ldc) + tidx.global[2]].x = 0.0;
@@ -93,8 +93,8 @@ hcblasStatus zgemm_alpha0_row(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x;
       CImg = C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[cOffset + tidx.global[1] + (tidx.global[0] * ldc)].x = 0.0;
@@ -131,8 +131,8 @@ hcblasStatus zgemm_alpha0_rowbatch(hc::accelerator_view accl_view,
     if (Row < N && Col < M) {
       CReal = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x;
       CImg = C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].y;
-      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(CReal)) ? 0 : CReal;
-      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(CImg)) ? 0 : CImg;
+      CReal = (hc::fast_math::isnan(CReal) || hc::fast_math::isinf(static_cast<float>(CReal))) ? 0 : CReal;
+      CImg = (hc::fast_math::isnan(CImg) || hc::fast_math::isinf(static_cast<float>(CImg))) ? 0 : CImg;
       if( !alpha.x && !alpha.y) {
        if( !beta.x && !beta.y) {
         C[elt][cOffset + tidx.global[2] + (tidx.global[1] * ldc)].x = 0.0;

--- a/test/include/helper_functions.h
+++ b/test/include/helper_functions.h
@@ -29,7 +29,7 @@ inline float sgemmCompareL2fe(const float *reference, const float *data,
     ref = std::inner_product(refVec.begin(), refVec.end(), refVec.begin(), ref);
     float normRef = sqrtf(ref);
 
-    if (fabs(ref) < 1e-7)
+    if (fabsf(ref) < 1e-7)
     {
 #ifdef _DEBUG
         std::cerr << "ERROR, reference l2-norm is 0\n";
@@ -73,8 +73,8 @@ inline float hgemmCompareL2fe(const half *reference, const  half *data,
     std::transform(diffVec.begin(), diffVec.end(), diffVec.begin(), diffVec.begin(), std::multiplies<half>());
     error = std::inner_product(diffVec.begin(), diffVec.end(), diffVec.begin(), error);
     ref = std::inner_product(refVec.begin(), refVec.end(), refVec.begin(), ref);
-    float normRef = sqrtf(fabs((float)ref));
-    if (fabs(float(ref)) < 1e-7)
+    float normRef = sqrtf(fabsf((float)ref));
+    if (fabsf(float(ref)) < 1e-7)
     {
 #ifdef _DEBUG
         std::cerr << "ERROR, reference l2-norm is 0\n";
@@ -113,7 +113,7 @@ inline void printDiff(float *data1, float *data2, int width, int height, int iLi
         for (i = 0; i < width; i++)
         {
             k = j * width + i;
-            float fDiff = fabs(data1[k] - data2[k]);
+            float fDiff = fabsf(data1[k] - data2[k]);
 
             if (fDiff > fListTol)
             {

--- a/test/unit-api/gtest-all.cpp
+++ b/test/unit-api/gtest-all.cpp
@@ -2342,7 +2342,7 @@ AssertionResult DoubleNearPredFormat(const char* expr1,
                                      double val1,
                                      double val2,
                                      double abs_error) {
-  const double diff = fabs(val1 - val2);
+  const double diff = fabsf(val1 - val2);
   if (diff <= abs_error) return AssertionSuccess();
 
   // TODO(wan): do not print the value of an expression if it's

--- a/test/unit-hip/gtest-all.cpp
+++ b/test/unit-hip/gtest-all.cpp
@@ -2342,7 +2342,7 @@ AssertionResult DoubleNearPredFormat(const char* expr1,
                                      double val1,
                                      double val2,
                                      double abs_error) {
-  const double diff = fabs(val1 - val2);
+  const double diff = fabsf(val1 - val2);
   if (diff <= abs_error) return AssertionSuccess();
 
   // TODO(wan): do not print the value of an expression if it's

--- a/test/unit/gtest-all.cpp
+++ b/test/unit/gtest-all.cpp
@@ -2342,7 +2342,7 @@ AssertionResult DoubleNearPredFormat(const char* expr1,
                                      double val1,
                                      double val2,
                                      double abs_error) {
-  const double diff = fabs(val1 - val2);
+  const double diff = fabsf(val1 - val2);
   if (diff <= abs_error) return AssertionSuccess();
 
   // TODO(wan): do not print the value of an expression if it's


### PR DESCRIPTION
This PR includes changes that:
1. add static_cast<float> for isinf, isnan math functions
2. change log2 and fmax apis to log2f and fmaxf

Have tested the changes with the tip of HCC/HIP, all dtests passed. 